### PR TITLE
User story/283/task/291/remove manual order all task

### DIFF
--- a/front-end/src/pages/AllTasks.jsx
+++ b/front-end/src/pages/AllTasks.jsx
@@ -249,9 +249,12 @@ export default function AllTasks({
 
   ];
   // Hide Manual Order only on Home page
+  // - Home page preview
+// - All Tasks page
+// Show ONLY on Project View (filterBy === "project")
   const isHomePageEmbedded = embedded && !filterBy && limit;
-
-  if (!isHomePageEmbedded) {
+  const isProjectView = filterBy === "project";
+  if (isProjectView) {
   sortOptions.push({ value: 'order', label: 'Manual Order' });
   }
   const filterOptions = [


### PR DESCRIPTION
fixed manual order to be displayed only in edit project and nowhere else. 